### PR TITLE
l10n: update translations

### DIFF
--- a/pkg/embed/locales/zh_CN/backend.po
+++ b/pkg/embed/locales/zh_CN/backend.po
@@ -13,10 +13,10 @@ msgstr ""
 "X-Crowdin-File-ID: 922\n"
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Simplified\n"
-"PO-Revision-Date: 2025-06-20 05:19\n"
+"PO-Revision-Date: 2025-07-07 10:34\n"
 
-#: internal/data/website.go:270
-#: internal/data/website.go:643
+#: internal/data/website.go:279
+#: internal/data/website.go:652
 msgid "# Rewrite rule"
 msgstr "# 伪静态规则"
 
@@ -1307,9 +1307,9 @@ msgstr "应用 %s 需要面板版本 %s，当前版本 %s"
 msgid "app not found"
 msgstr "应用未找到"
 
-#: internal/data/setting.go:282
-#: internal/data/setting.go:343
-#: internal/data/setting.go:356
+#: internal/data/setting.go:283
+#: internal/data/setting.go:345
+#: internal/data/setting.go:358
 msgid "background task is running, modifying some settings is prohibited, please try again later"
 msgstr "后台任务正在运行，禁止修改某些设置，请稍后再试"
 
@@ -1331,7 +1331,7 @@ msgstr "备份文件 %s 不存在"
 msgid "can't download a directory"
 msgstr "无法下载目录"
 
-#: internal/data/website.go:371
+#: internal/data/website.go:380
 msgid "can't find %s database server, please add it first"
 msgstr "找不到 %s 数据库服务器，请先添加"
 
@@ -1367,11 +1367,11 @@ msgstr "cron 日志目录 %s 不存在"
 msgid "database does not exist: %s"
 msgstr "数据库不存在：%s"
 
-#: internal/data/website.go:725
+#: internal/data/website.go:734
 msgid "default document comment count is incorrect, expected 1, actual %d"
 msgstr "默认文档注释数量不正确，预期为1，实际为 %d"
 
-#: internal/data/website.go:722
+#: internal/data/website.go:731
 msgid "default document comment not found"
 msgstr "未找到默认文档注释"
 
@@ -1439,7 +1439,7 @@ msgstr "获取 %s 服务启用状态失败：%v"
 msgid "failed to get %s service running status: %v"
 msgstr "获取 %s 服务运行状态失败：%v"
 
-#: internal/data/website.go:306
+#: internal/data/website.go:315
 msgid "failed to get 404 template file: %v"
 msgstr "获取404模板文件失败：%v"
 
@@ -1512,7 +1512,7 @@ msgstr "获取磁盘空间失败： %v"
 msgid "failed to get home apps: %v"
 msgstr "获取主页应用失败： %v"
 
-#: internal/data/website.go:294
+#: internal/data/website.go:303
 msgid "failed to get index template file: %v"
 msgstr "获取首页模板文件失败：%v"
 
@@ -1598,18 +1598,18 @@ msgid "failed to load MySQL root password: %v"
 msgstr "加载 MySQL root 密码失败： %v"
 
 #: internal/data/cert.go:92
-#: internal/data/setting.go:287
-#: internal/data/setting.go:359
-#: internal/data/website.go:475
-#: internal/data/website.go:764
+#: internal/data/setting.go:288
+#: internal/data/setting.go:361
+#: internal/data/website.go:484
+#: internal/data/website.go:773
 msgid "failed to parse certificate: %v"
 msgstr "解析证书失败： %v"
 
 #: internal/data/cert.go:95
-#: internal/data/setting.go:290
-#: internal/data/setting.go:362
-#: internal/data/website.go:478
-#: internal/data/website.go:767
+#: internal/data/setting.go:291
+#: internal/data/setting.go:364
+#: internal/data/website.go:487
+#: internal/data/website.go:776
 msgid "failed to parse private key: %v"
 msgstr "解析私钥失败： %v"
 
@@ -1729,13 +1729,13 @@ msgstr "gRPC 是一个高性能、开源和通用的 RPC 框架"
 msgid "get service port failed, please check if it is installed"
 msgstr "获取服务端口失败，请检查是否安装"
 
-#: internal/data/user.go:170
-#: internal/data/user.go:189
+#: internal/data/user.go:180
+#: internal/data/user.go:199
 #: internal/service/user.go:96
 msgid "invalid 2FA code"
 msgstr "无效的两步验证代码"
 
-#: internal/http/middleware/entrance.go:107
+#: internal/http/middleware/entrance.go:110
 msgid "invalid access entrance"
 msgstr "无效的访问入口"
 
@@ -1807,7 +1807,7 @@ msgstr "挂载路径不为空"
 msgid "mysql not support database comment"
 msgstr "mysql 不支持数据库注释"
 
-#: internal/data/website.go:795
+#: internal/data/website.go:804
 msgid "not support one-key obtain wildcard certificate, please use Cert menu to obtain it with DNS method"
 msgstr "不支持一键获取通配符证书，请在证书菜单通过 DNS 方法获取"
 
@@ -1852,7 +1852,7 @@ msgstr "没有找到 phpMyAdmin 目录"
 msgid "phpMyAdmin port not found"
 msgstr "没有找到 phpMyAdmin 端口"
 
-#: internal/data/user.go:96
+#: internal/data/user.go:106
 #: internal/service/file.go:135
 #: internal/service/file.go:222
 #: internal/service/file.go:251
@@ -1863,7 +1863,7 @@ msgstr "请不要花样作死"
 msgid "please retry the manual obtain operation"
 msgstr "请重新操作手动签发"
 
-#: internal/data/setting.go:311
+#: internal/data/setting.go:312
 msgid "port is already in use"
 msgstr "端口已被占用"
 
@@ -1883,16 +1883,16 @@ msgstr "规则已存在"
 msgid "rule not found"
 msgstr "找不到规则"
 
-#: internal/data/website.go:712
+#: internal/data/website.go:721
 msgid "runtime directory comment count is incorrect, expected 1, actual %d"
 msgstr "运行时目录注释数量不正确，预期为1，实际为%d"
 
-#: internal/data/website.go:709
+#: internal/data/website.go:718
 msgid "runtime directory comment not found"
 msgstr "未找到运行目录注释"
 
-#: internal/data/website.go:449
-#: internal/data/website.go:716
+#: internal/data/website.go:458
+#: internal/data/website.go:725
 msgid "runtime directory does not exist"
 msgstr "运行目录不存在"
 
@@ -1994,17 +1994,17 @@ msgstr "上传的证书无法设置为自动续签"
 msgid "upload file error: %v"
 msgstr "上传文件错误：%v"
 
-#: internal/data/user.go:116
-#: internal/data/user.go:123
+#: internal/data/user.go:126
 #: internal/data/user.go:133
+#: internal/data/user.go:143
 msgid "username or password error"
 msgstr "用户名或密码错误"
 
-#: internal/data/website.go:560
+#: internal/data/website.go:569
 msgid "website %s has bound certificates, please delete the certificate first"
 msgstr "网站 %s 已绑定证书，请先删除证书"
 
-#: internal/data/website.go:456
+#: internal/data/website.go:465
 msgid "website directory does not exist"
 msgstr "网站目录不存在"
 

--- a/pkg/embed/locales/zh_TW/backend.po
+++ b/pkg/embed/locales/zh_TW/backend.po
@@ -13,10 +13,10 @@ msgstr ""
 "X-Crowdin-File-ID: 922\n"
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Traditional\n"
-"PO-Revision-Date: 2025-06-20 05:19\n"
+"PO-Revision-Date: 2025-07-07 10:34\n"
 
-#: internal/data/website.go:270
-#: internal/data/website.go:643
+#: internal/data/website.go:279
+#: internal/data/website.go:652
 msgid "# Rewrite rule"
 msgstr "# 重寫規則"
 
@@ -1307,9 +1307,9 @@ msgstr "應用程式 %s 需要面板版本 %s，目前版本 %s"
 msgid "app not found"
 msgstr "找不到應用"
 
-#: internal/data/setting.go:282
-#: internal/data/setting.go:343
-#: internal/data/setting.go:356
+#: internal/data/setting.go:283
+#: internal/data/setting.go:345
+#: internal/data/setting.go:358
 msgid "background task is running, modifying some settings is prohibited, please try again later"
 msgstr "後台任務正在運行，禁止修改某些設置，請稍後再試"
 
@@ -1331,7 +1331,7 @@ msgstr "備份檔案 %s 不存在"
 msgid "can't download a directory"
 msgstr "無法下載目錄"
 
-#: internal/data/website.go:371
+#: internal/data/website.go:380
 msgid "can't find %s database server, please add it first"
 msgstr "找不到 %s 數據庫服務器，請先添加"
 
@@ -1367,11 +1367,11 @@ msgstr "cron 日誌目錄 %s 不存在"
 msgid "database does not exist: %s"
 msgstr "資料庫不存在：%s"
 
-#: internal/data/website.go:725
+#: internal/data/website.go:734
 msgid "default document comment count is incorrect, expected 1, actual %d"
 msgstr "默認文檔註釋數量不正確，預期為1，實際為 %d"
 
-#: internal/data/website.go:722
+#: internal/data/website.go:731
 msgid "default document comment not found"
 msgstr "未找到預設文件註釋"
 
@@ -1439,7 +1439,7 @@ msgstr "無法獲取 %s 服務啟用狀態：%v"
 msgid "failed to get %s service running status: %v"
 msgstr "無法獲取 %s 服務運行狀態：%v"
 
-#: internal/data/website.go:306
+#: internal/data/website.go:315
 msgid "failed to get 404 template file: %v"
 msgstr "獲取404模板文件失敗：%v"
 
@@ -1512,7 +1512,7 @@ msgstr "無法獲取磁盤空間：%v"
 msgid "failed to get home apps: %v"
 msgstr "無法獲取主頁應用：%v"
 
-#: internal/data/website.go:294
+#: internal/data/website.go:303
 msgid "failed to get index template file: %v"
 msgstr "獲取首頁模板文件失敗：%v"
 
@@ -1598,18 +1598,18 @@ msgid "failed to load MySQL root password: %v"
 msgstr "無法載入 MySQL root 密碼：%v"
 
 #: internal/data/cert.go:92
-#: internal/data/setting.go:287
-#: internal/data/setting.go:359
-#: internal/data/website.go:475
-#: internal/data/website.go:764
+#: internal/data/setting.go:288
+#: internal/data/setting.go:361
+#: internal/data/website.go:484
+#: internal/data/website.go:773
 msgid "failed to parse certificate: %v"
 msgstr "無法解析證書：%v"
 
 #: internal/data/cert.go:95
-#: internal/data/setting.go:290
-#: internal/data/setting.go:362
-#: internal/data/website.go:478
-#: internal/data/website.go:767
+#: internal/data/setting.go:291
+#: internal/data/setting.go:364
+#: internal/data/website.go:487
+#: internal/data/website.go:776
 msgid "failed to parse private key: %v"
 msgstr "解析私鑰失敗：%v"
 
@@ -1729,13 +1729,13 @@ msgstr "gRPC 是一個高性能、開源和通用的 RPC 框架"
 msgid "get service port failed, please check if it is installed"
 msgstr "獲取服務端口失敗，請檢查是否安裝"
 
-#: internal/data/user.go:170
-#: internal/data/user.go:189
+#: internal/data/user.go:180
+#: internal/data/user.go:199
 #: internal/service/user.go:96
 msgid "invalid 2FA code"
 msgstr "無效的兩步驗證代碼"
 
-#: internal/http/middleware/entrance.go:107
+#: internal/http/middleware/entrance.go:110
 msgid "invalid access entrance"
 msgstr "無效的訪問入口"
 
@@ -1807,7 +1807,7 @@ msgstr "掛載路徑不為空"
 msgid "mysql not support database comment"
 msgstr "mysql 不支援資料庫註釋"
 
-#: internal/data/website.go:795
+#: internal/data/website.go:804
 msgid "not support one-key obtain wildcard certificate, please use Cert menu to obtain it with DNS method"
 msgstr "不支持一鍵獲取通配符證書，請在證書菜單通過 DNS 方法獲取"
 
@@ -1852,7 +1852,7 @@ msgstr "未找到 phpMyAdmin 目錄"
 msgid "phpMyAdmin port not found"
 msgstr "未找到 phpMyAdmin 端口"
 
-#: internal/data/user.go:96
+#: internal/data/user.go:106
 #: internal/service/file.go:135
 #: internal/service/file.go:222
 #: internal/service/file.go:251
@@ -1863,7 +1863,7 @@ msgstr "請不要這樣做"
 msgid "please retry the manual obtain operation"
 msgstr "請重新操作手動簽發"
 
-#: internal/data/setting.go:311
+#: internal/data/setting.go:312
 msgid "port is already in use"
 msgstr "端口已被佔用"
 
@@ -1883,16 +1883,16 @@ msgstr "規則已存在"
 msgid "rule not found"
 msgstr "找不到規則"
 
-#: internal/data/website.go:712
+#: internal/data/website.go:721
 msgid "runtime directory comment count is incorrect, expected 1, actual %d"
 msgstr "運行時目錄註釋數量不正確，預期為1，實際為%d"
 
-#: internal/data/website.go:709
+#: internal/data/website.go:718
 msgid "runtime directory comment not found"
 msgstr "未找到運行目錄註釋"
 
-#: internal/data/website.go:449
-#: internal/data/website.go:716
+#: internal/data/website.go:458
+#: internal/data/website.go:725
 msgid "runtime directory does not exist"
 msgstr "運行目錄不存在"
 
@@ -1994,17 +1994,17 @@ msgstr "上傳的憑證無法設定為自動續簽"
 msgid "upload file error: %v"
 msgstr "上傳檔案錯誤：%v"
 
-#: internal/data/user.go:116
-#: internal/data/user.go:123
+#: internal/data/user.go:126
 #: internal/data/user.go:133
+#: internal/data/user.go:143
 msgid "username or password error"
 msgstr "使用者名稱或密碼錯誤"
 
-#: internal/data/website.go:560
+#: internal/data/website.go:569
 msgid "website %s has bound certificates, please delete the certificate first"
 msgstr "網站 %s 已綁定證書，請先刪除證書"
 
-#: internal/data/website.go:456
+#: internal/data/website.go:465
 msgid "website directory does not exist"
 msgstr "網站目錄不存在"
 

--- a/web/src/locales/zh_CN.po
+++ b/web/src/locales/zh_CN.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-06-08 07:54\n"
+"PO-Revision-Date: 2025-07-07 09:54\n"
 
 #: src/components/common/AppFooter.vue:13
 #: src/views/dashboard/IndexView.vue:439
@@ -180,7 +180,7 @@ msgstr "文件夹"
 #: src/components/common/PathSelector.vue:323
 #: src/views/setting/TokenModal.vue:268
 #: src/views/website/BulkCreate.vue:127
-#: src/views/website/IndexView.vue:539
+#: src/views/website/IndexView.vue:571
 msgid "Create"
 msgstr "创建"
 
@@ -282,7 +282,7 @@ msgstr "正在启动……"
 
 #: src/components/common/ServiceStatus.vue:48
 #: src/views/apps/supervisor/IndexView.vue:248
-#: src/views/website/IndexView.vue:239
+#: src/views/website/IndexView.vue:271
 msgid "Started successfully"
 msgstr "启动成功"
 
@@ -293,7 +293,7 @@ msgstr "停止中..."
 
 #: src/components/common/ServiceStatus.vue:63
 #: src/views/apps/supervisor/IndexView.vue:255
-#: src/views/website/IndexView.vue:241
+#: src/views/website/IndexView.vue:273
 msgid "Stopped successfully"
 msgstr "停止成功"
 
@@ -411,7 +411,7 @@ msgstr "设置主题颜色"
 #: src/views/apps/pureftpd/IndexView.vue:65
 #: src/views/apps/pureftpd/IndexView.vue:256
 #: src/views/setting/PasswordModal.vue:26
-#: src/views/setting/SettingUser.vue:109
+#: src/views/setting/SettingUser.vue:119
 msgid "Change Password"
 msgstr "更改密码"
 
@@ -536,7 +536,7 @@ msgstr "更新"
 #: src/views/backup/ListView.vue:264
 #: src/views/dashboard/IndexView.vue:425
 #: src/views/database/IndexView.vue:45
-#: src/views/website/IndexView.vue:460
+#: src/views/website/IndexView.vue:492
 msgid "Database"
 msgstr "数据库"
 
@@ -670,12 +670,12 @@ msgstr "在主页显示"
 #: src/views/firewall/ForwardView.vue:80
 #: src/views/firewall/IpRuleView.vue:122
 #: src/views/firewall/RuleView.vue:159
-#: src/views/setting/SettingUser.vue:76
+#: src/views/setting/SettingUser.vue:86
 #: src/views/setting/TokenModal.vue:52
 #: src/views/task/CronView.vue:102
 #: src/views/task/SystemView.vue:96
 #: src/views/task/TaskView.vue:55
-#: src/views/website/IndexView.vue:94
+#: src/views/website/IndexView.vue:126
 msgid "Actions"
 msgstr "操作"
 
@@ -865,12 +865,12 @@ msgstr "您确定要删除规则 %{ name } 吗？"
 #: src/views/firewall/ForwardView.vue:104
 #: src/views/firewall/IpRuleView.vue:146
 #: src/views/firewall/RuleView.vue:183
-#: src/views/setting/SettingUser.vue:132
+#: src/views/setting/SettingUser.vue:142
 #: src/views/setting/TokenModal.vue:92
 #: src/views/ssh/IndexView.vue:93
 #: src/views/task/CronView.vue:155
 #: src/views/task/TaskView.vue:98
-#: src/views/website/IndexView.vue:167
+#: src/views/website/IndexView.vue:199
 msgid "Delete"
 msgstr "删除"
 
@@ -910,12 +910,12 @@ msgstr "添加成功"
 #: src/views/firewall/IpRuleView.vue:191
 #: src/views/firewall/RuleView.vue:210
 #: src/views/firewall/RuleView.vue:228
-#: src/views/setting/SettingUser.vue:162
+#: src/views/setting/SettingUser.vue:178
 #: src/views/setting/TokenModal.vue:116
 #: src/views/task/CronView.vue:198
 #: src/views/task/TaskView.vue:124
-#: src/views/website/IndexView.vue:269
-#: src/views/website/IndexView.vue:325
+#: src/views/website/IndexView.vue:301
+#: src/views/website/IndexView.vue:357
 msgid "Deleted successfully"
 msgstr "删除成功"
 
@@ -1081,11 +1081,12 @@ msgstr "清除成功"
 #: src/views/database/UpdateUserModal.vue:18
 #: src/views/database/UserList.vue:222
 #: src/views/file/PermissionModal.vue:29
-#: src/views/setting/SettingUser.vue:156
+#: src/views/setting/SettingUser.vue:166
+#: src/views/setting/SettingUser.vue:172
 #: src/views/task/CronView.vue:180
 #: src/views/task/CronView.vue:207
-#: src/views/website/IndexView.vue:252
-#: src/views/website/IndexView.vue:278
+#: src/views/website/IndexView.vue:284
+#: src/views/website/IndexView.vue:310
 msgid "Modified successfully"
 msgstr "修改成功"
 
@@ -1329,7 +1330,7 @@ msgstr "建议使用生成器生成随机密码"
 #: src/views/apps/rsync/IndexView.vue:342
 #: src/views/container/ComposeView.vue:38
 #: src/views/website/IndexView.vue:44
-#: src/views/website/IndexView.vue:517
+#: src/views/website/IndexView.vue:549
 msgid "Directory"
 msgstr "目录"
 
@@ -1590,8 +1591,8 @@ msgstr "选择网站"
 #: src/views/database/DatabaseList.vue:35
 #: src/views/task/CreateModal.vue:154
 #: src/views/task/CreateModal.vue:156
-#: src/views/website/IndexView.vue:481
-#: src/views/website/IndexView.vue:486
+#: src/views/website/IndexView.vue:513
+#: src/views/website/IndexView.vue:518
 msgid "Database Name"
 msgstr "数据库名称"
 
@@ -1633,7 +1634,7 @@ msgstr "对于大文件，建议使用 SFTP 或其他方法上传"
 #: src/views/cert/AccountView.vue:243
 #: src/views/cert/CreateAccountModal.vue:100
 #: src/views/setting/CreateModal.vue:56
-#: src/views/setting/SettingUser.vue:26
+#: src/views/setting/SettingUser.vue:36
 msgid "Email"
 msgstr "邮箱"
 
@@ -1730,7 +1731,7 @@ msgstr "输入 HMAC"
 #: src/views/cert/CreateCertModal.vue:74
 #: src/views/cert/ObtainModal.vue:57
 #: src/views/website/EditView.vue:232
-#: src/views/website/IndexView.vue:425
+#: src/views/website/IndexView.vue:457
 msgid "Domain"
 msgstr "域名"
 
@@ -2120,7 +2121,7 @@ msgstr "签发模式"
 #: src/views/container/ImageView.vue:60
 #: src/views/container/NetworkView.vue:100
 #: src/views/container/VolumeView.vue:54
-#: src/views/setting/SettingUser.vue:67
+#: src/views/setting/SettingUser.vue:77
 #: src/views/setting/TokenModal.vue:34
 #: src/views/task/CronView.vue:83
 #: src/views/task/TaskView.vue:37
@@ -2132,7 +2133,7 @@ msgstr "创建时间"
 #: src/views/file/ListTable.vue:220
 #: src/views/ssh/IndexView.vue:71
 #: src/views/task/CronView.vue:133
-#: src/views/website/IndexView.vue:109
+#: src/views/website/IndexView.vue:141
 msgid "Edit"
 msgstr "编辑"
 
@@ -3059,7 +3060,7 @@ msgstr "输入数据库服务器主机"
 #: src/views/setting/SettingBase.vue:49
 #: src/views/ssh/CreateModal.vue:68
 #: src/views/ssh/UpdateModal.vue:74
-#: src/views/website/IndexView.vue:436
+#: src/views/website/IndexView.vue:468
 msgid "Port"
 msgstr "端口"
 
@@ -3553,7 +3554,7 @@ msgstr "请选择要删除的规则"
 #: src/views/firewall/ForwardView.vue:172
 #: src/views/firewall/IpRuleView.vue:214
 #: src/views/firewall/RuleView.vue:251
-#: src/views/website/IndexView.vue:357
+#: src/views/website/IndexView.vue:389
 msgid "Batch Delete"
 msgstr "批量删除"
 
@@ -3838,20 +3839,20 @@ msgstr "自动更新"
 msgid "Panel HTTPS"
 msgstr "面板 HTTPS"
 
-#: src/views/setting/SettingUser.vue:43
+#: src/views/setting/SettingUser.vue:53
 msgid "2FA"
 msgstr "两步验证"
 
-#: src/views/setting/SettingUser.vue:58
+#: src/views/setting/SettingUser.vue:68
 msgid "Disabled successfully"
 msgstr "禁用成功"
 
-#: src/views/setting/SettingUser.vue:93
+#: src/views/setting/SettingUser.vue:103
 #: src/views/setting/TokenModal.vue:204
 msgid "Access Tokens"
 msgstr "访问令牌"
 
-#: src/views/setting/SettingUser.vue:121
+#: src/views/setting/SettingUser.vue:131
 msgid "Are you sure you want to delete this user?"
 msgstr "您确定要删除该用户吗？"
 
@@ -4254,12 +4255,12 @@ msgid "The format is incorrect, please check"
 msgstr "格式不正确，请检查"
 
 #: src/views/website/BulkCreate.vue:59
-#: src/views/website/IndexView.vue:295
+#: src/views/website/IndexView.vue:327
 msgid "Website %{ name } created successfully"
 msgstr "网站 %{ name } 创建成功"
 
 #: src/views/website/BulkCreate.vue:77
-#: src/views/website/IndexView.vue:368
+#: src/views/website/IndexView.vue:400
 msgid "Bulk Create Website"
 msgstr "批量创建网站"
 
@@ -4292,7 +4293,7 @@ msgid "Remark: The remark of the website, can be empty."
 msgstr "备注：网站的备注，可以为空。"
 
 #: src/views/website/EditView.vue:54
-#: src/views/website/IndexView.vue:209
+#: src/views/website/IndexView.vue:241
 msgid "Not used"
 msgstr "未使用"
 
@@ -4374,12 +4375,12 @@ msgid "Default Document"
 msgstr "默认文档"
 
 #: src/views/website/EditView.vue:277
-#: src/views/website/IndexView.vue:448
+#: src/views/website/IndexView.vue:480
 msgid "PHP Version"
 msgstr "PHP 版本"
 
 #: src/views/website/EditView.vue:282
-#: src/views/website/IndexView.vue:452
+#: src/views/website/IndexView.vue:484
 msgid "Select PHP Version"
 msgstr "选择 PHP 版本"
 
@@ -4446,75 +4447,91 @@ msgid "Error Log"
 msgstr "错误日志"
 
 #: src/views/website/IndexView.vue:24
-#: src/views/website/IndexView.vue:411
+#: src/views/website/IndexView.vue:443
 msgid "Website Name"
 msgstr "网站名称"
 
 #: src/views/website/IndexView.vue:77
-#: src/views/website/IndexView.vue:529
-#: src/views/website/IndexView.vue:534
+msgid "Certificate expiration"
+msgstr ""
+
+#: src/views/website/IndexView.vue:91
+msgid "Not configured"
+msgstr ""
+
+#: src/views/website/IndexView.vue:94
+msgid "Expired %{ days } days ago"
+msgstr ""
+
+#: src/views/website/IndexView.vue:99
+msgid "Expires in %{ days } days"
+msgstr ""
+
+#: src/views/website/IndexView.vue:109
+#: src/views/website/IndexView.vue:561
+#: src/views/website/IndexView.vue:566
 msgid "Remark"
 msgstr "备注"
 
-#: src/views/website/IndexView.vue:133
+#: src/views/website/IndexView.vue:165
 msgid "Are you sure you want to delete website %{ name }?"
 msgstr "您确定要删除网站 %{ name } 吗？"
 
-#: src/views/website/IndexView.vue:144
+#: src/views/website/IndexView.vue:176
 msgid "Delete website directory"
 msgstr "删除网站目录"
 
-#: src/views/website/IndexView.vue:152
+#: src/views/website/IndexView.vue:184
 msgid "Delete local database with the same name"
 msgstr "删除同名的本地数据库"
 
-#: src/views/website/IndexView.vue:316
+#: src/views/website/IndexView.vue:348
 msgid "Please select the websites to delete"
 msgstr "请选择要删除的网站"
 
-#: src/views/website/IndexView.vue:351
-#: src/views/website/IndexView.vue:545
+#: src/views/website/IndexView.vue:383
+#: src/views/website/IndexView.vue:577
 msgid "Modify Default Page"
 msgstr "修改默认页面"
 
-#: src/views/website/IndexView.vue:361
+#: src/views/website/IndexView.vue:393
 msgid "This will delete the website directory but not the database with the same name. Are you sure you want to delete the selected websites?"
 msgstr "这将删除网站目录，但不会删除同名的数据库。您确定要删除所选网站吗？"
 
-#: src/views/website/IndexView.vue:372
-#: src/views/website/IndexView.vue:402
+#: src/views/website/IndexView.vue:404
+#: src/views/website/IndexView.vue:434
 msgid "Create Website"
 msgstr "创建网站"
 
-#: src/views/website/IndexView.vue:417
+#: src/views/website/IndexView.vue:449
 msgid "Recommended to use English for the website name, it cannot be modified after setting"
 msgstr "建议使用英文作为网站名称，设置后无法修改"
 
-#: src/views/website/IndexView.vue:464
+#: src/views/website/IndexView.vue:496
 msgid "Select Database"
 msgstr "选择数据库"
 
-#: src/views/website/IndexView.vue:492
-#: src/views/website/IndexView.vue:497
+#: src/views/website/IndexView.vue:524
+#: src/views/website/IndexView.vue:529
 msgid "Database User"
 msgstr "数据库用户"
 
-#: src/views/website/IndexView.vue:506
-#: src/views/website/IndexView.vue:512
+#: src/views/website/IndexView.vue:538
+#: src/views/website/IndexView.vue:544
 msgid "Database Password"
 msgstr "数据库密码"
 
-#: src/views/website/IndexView.vue:523
+#: src/views/website/IndexView.vue:555
 msgid "Website root directory (if left empty, defaults to website directory/website name)"
 msgstr "网站根目录（如果留空，默认为网站目录/网站名称）"
 
-#: src/views/website/IndexView.vue:553
-#: src/views/website/IndexView.vue:553
+#: src/views/website/IndexView.vue:585
+#: src/views/website/IndexView.vue:585
 msgid "Default Page"
 msgstr "默认页面"
 
-#: src/views/website/IndexView.vue:567
-#: src/views/website/IndexView.vue:567
+#: src/views/website/IndexView.vue:599
+#: src/views/website/IndexView.vue:599
 msgid "Stop Page"
 msgstr "停止页面"
 

--- a/web/src/locales/zh_CN.po
+++ b/web/src/locales/zh_CN.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-07-07 09:54\n"
+"PO-Revision-Date: 2025-07-07 10:33\n"
 
 #: src/components/common/AppFooter.vue:13
 #: src/views/dashboard/IndexView.vue:439
@@ -4453,19 +4453,19 @@ msgstr "网站名称"
 
 #: src/views/website/IndexView.vue:77
 msgid "Certificate expiration"
-msgstr ""
+msgstr "证书有效期"
 
 #: src/views/website/IndexView.vue:91
 msgid "Not configured"
-msgstr ""
+msgstr "未配置"
 
 #: src/views/website/IndexView.vue:94
 msgid "Expired %{ days } days ago"
-msgstr ""
+msgstr "%{ days } 天前过期"
 
 #: src/views/website/IndexView.vue:99
 msgid "Expires in %{ days } days"
-msgstr ""
+msgstr "%{ days } 天后过期"
 
 #: src/views/website/IndexView.vue:109
 #: src/views/website/IndexView.vue:561

--- a/web/src/locales/zh_TW.po
+++ b/web/src/locales/zh_TW.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-07-07 09:54\n"
+"PO-Revision-Date: 2025-07-07 10:34\n"
 
 #: src/components/common/AppFooter.vue:13
 #: src/views/dashboard/IndexView.vue:439
@@ -4453,19 +4453,19 @@ msgstr "網站名稱"
 
 #: src/views/website/IndexView.vue:77
 msgid "Certificate expiration"
-msgstr ""
+msgstr "證書有效期限"
 
 #: src/views/website/IndexView.vue:91
 msgid "Not configured"
-msgstr ""
+msgstr "未設定"
 
 #: src/views/website/IndexView.vue:94
 msgid "Expired %{ days } days ago"
-msgstr ""
+msgstr "%{ days } 天前過期"
 
 #: src/views/website/IndexView.vue:99
 msgid "Expires in %{ days } days"
-msgstr ""
+msgstr "%{ days } 天後過期"
 
 #: src/views/website/IndexView.vue:109
 #: src/views/website/IndexView.vue:561

--- a/web/src/locales/zh_TW.po
+++ b/web/src/locales/zh_TW.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: ratpanel\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-06-08 07:54\n"
+"PO-Revision-Date: 2025-07-07 09:54\n"
 
 #: src/components/common/AppFooter.vue:13
 #: src/views/dashboard/IndexView.vue:439
@@ -180,7 +180,7 @@ msgstr "文件夾"
 #: src/components/common/PathSelector.vue:323
 #: src/views/setting/TokenModal.vue:268
 #: src/views/website/BulkCreate.vue:127
-#: src/views/website/IndexView.vue:539
+#: src/views/website/IndexView.vue:571
 msgid "Create"
 msgstr "創建"
 
@@ -282,7 +282,7 @@ msgstr "正在啟動……"
 
 #: src/components/common/ServiceStatus.vue:48
 #: src/views/apps/supervisor/IndexView.vue:248
-#: src/views/website/IndexView.vue:239
+#: src/views/website/IndexView.vue:271
 msgid "Started successfully"
 msgstr "啟動成功"
 
@@ -293,7 +293,7 @@ msgstr "停止中..."
 
 #: src/components/common/ServiceStatus.vue:63
 #: src/views/apps/supervisor/IndexView.vue:255
-#: src/views/website/IndexView.vue:241
+#: src/views/website/IndexView.vue:273
 msgid "Stopped successfully"
 msgstr "停止成功"
 
@@ -411,7 +411,7 @@ msgstr "設置主題顏色"
 #: src/views/apps/pureftpd/IndexView.vue:65
 #: src/views/apps/pureftpd/IndexView.vue:256
 #: src/views/setting/PasswordModal.vue:26
-#: src/views/setting/SettingUser.vue:109
+#: src/views/setting/SettingUser.vue:119
 msgid "Change Password"
 msgstr "更改密碼"
 
@@ -536,7 +536,7 @@ msgstr "更新"
 #: src/views/backup/ListView.vue:264
 #: src/views/dashboard/IndexView.vue:425
 #: src/views/database/IndexView.vue:45
-#: src/views/website/IndexView.vue:460
+#: src/views/website/IndexView.vue:492
 msgid "Database"
 msgstr "數據庫"
 
@@ -670,12 +670,12 @@ msgstr "在主頁顯示"
 #: src/views/firewall/ForwardView.vue:80
 #: src/views/firewall/IpRuleView.vue:122
 #: src/views/firewall/RuleView.vue:159
-#: src/views/setting/SettingUser.vue:76
+#: src/views/setting/SettingUser.vue:86
 #: src/views/setting/TokenModal.vue:52
 #: src/views/task/CronView.vue:102
 #: src/views/task/SystemView.vue:96
 #: src/views/task/TaskView.vue:55
-#: src/views/website/IndexView.vue:94
+#: src/views/website/IndexView.vue:126
 msgid "Actions"
 msgstr "操作"
 
@@ -865,12 +865,12 @@ msgstr "您確定要刪除規則 %{ name } 嗎？"
 #: src/views/firewall/ForwardView.vue:104
 #: src/views/firewall/IpRuleView.vue:146
 #: src/views/firewall/RuleView.vue:183
-#: src/views/setting/SettingUser.vue:132
+#: src/views/setting/SettingUser.vue:142
 #: src/views/setting/TokenModal.vue:92
 #: src/views/ssh/IndexView.vue:93
 #: src/views/task/CronView.vue:155
 #: src/views/task/TaskView.vue:98
-#: src/views/website/IndexView.vue:167
+#: src/views/website/IndexView.vue:199
 msgid "Delete"
 msgstr "刪除"
 
@@ -910,12 +910,12 @@ msgstr "添加成功"
 #: src/views/firewall/IpRuleView.vue:191
 #: src/views/firewall/RuleView.vue:210
 #: src/views/firewall/RuleView.vue:228
-#: src/views/setting/SettingUser.vue:162
+#: src/views/setting/SettingUser.vue:178
 #: src/views/setting/TokenModal.vue:116
 #: src/views/task/CronView.vue:198
 #: src/views/task/TaskView.vue:124
-#: src/views/website/IndexView.vue:269
-#: src/views/website/IndexView.vue:325
+#: src/views/website/IndexView.vue:301
+#: src/views/website/IndexView.vue:357
 msgid "Deleted successfully"
 msgstr "刪除成功"
 
@@ -1081,11 +1081,12 @@ msgstr "清除成功"
 #: src/views/database/UpdateUserModal.vue:18
 #: src/views/database/UserList.vue:222
 #: src/views/file/PermissionModal.vue:29
-#: src/views/setting/SettingUser.vue:156
+#: src/views/setting/SettingUser.vue:166
+#: src/views/setting/SettingUser.vue:172
 #: src/views/task/CronView.vue:180
 #: src/views/task/CronView.vue:207
-#: src/views/website/IndexView.vue:252
-#: src/views/website/IndexView.vue:278
+#: src/views/website/IndexView.vue:284
+#: src/views/website/IndexView.vue:310
 msgid "Modified successfully"
 msgstr "修改成功"
 
@@ -1329,7 +1330,7 @@ msgstr "建議使用生成器生成隨機密碼"
 #: src/views/apps/rsync/IndexView.vue:342
 #: src/views/container/ComposeView.vue:38
 #: src/views/website/IndexView.vue:44
-#: src/views/website/IndexView.vue:517
+#: src/views/website/IndexView.vue:549
 msgid "Directory"
 msgstr "目錄"
 
@@ -1590,8 +1591,8 @@ msgstr "選擇網站"
 #: src/views/database/DatabaseList.vue:35
 #: src/views/task/CreateModal.vue:154
 #: src/views/task/CreateModal.vue:156
-#: src/views/website/IndexView.vue:481
-#: src/views/website/IndexView.vue:486
+#: src/views/website/IndexView.vue:513
+#: src/views/website/IndexView.vue:518
 msgid "Database Name"
 msgstr "數據庫名稱"
 
@@ -1633,7 +1634,7 @@ msgstr "對於大文件，建議使用 SFTP 或其他方法上傳"
 #: src/views/cert/AccountView.vue:243
 #: src/views/cert/CreateAccountModal.vue:100
 #: src/views/setting/CreateModal.vue:56
-#: src/views/setting/SettingUser.vue:26
+#: src/views/setting/SettingUser.vue:36
 msgid "Email"
 msgstr "電子郵件"
 
@@ -1730,7 +1731,7 @@ msgstr "輸入 HMAC"
 #: src/views/cert/CreateCertModal.vue:74
 #: src/views/cert/ObtainModal.vue:57
 #: src/views/website/EditView.vue:232
-#: src/views/website/IndexView.vue:425
+#: src/views/website/IndexView.vue:457
 msgid "Domain"
 msgstr "域名"
 
@@ -2120,7 +2121,7 @@ msgstr "簽發模式"
 #: src/views/container/ImageView.vue:60
 #: src/views/container/NetworkView.vue:100
 #: src/views/container/VolumeView.vue:54
-#: src/views/setting/SettingUser.vue:67
+#: src/views/setting/SettingUser.vue:77
 #: src/views/setting/TokenModal.vue:34
 #: src/views/task/CronView.vue:83
 #: src/views/task/TaskView.vue:37
@@ -2132,7 +2133,7 @@ msgstr "創建時間"
 #: src/views/file/ListTable.vue:220
 #: src/views/ssh/IndexView.vue:71
 #: src/views/task/CronView.vue:133
-#: src/views/website/IndexView.vue:109
+#: src/views/website/IndexView.vue:141
 msgid "Edit"
 msgstr "編輯"
 
@@ -3059,7 +3060,7 @@ msgstr "輸入數據庫伺服器主機"
 #: src/views/setting/SettingBase.vue:49
 #: src/views/ssh/CreateModal.vue:68
 #: src/views/ssh/UpdateModal.vue:74
-#: src/views/website/IndexView.vue:436
+#: src/views/website/IndexView.vue:468
 msgid "Port"
 msgstr "端口"
 
@@ -3553,7 +3554,7 @@ msgstr "請選擇要刪除的規則"
 #: src/views/firewall/ForwardView.vue:172
 #: src/views/firewall/IpRuleView.vue:214
 #: src/views/firewall/RuleView.vue:251
-#: src/views/website/IndexView.vue:357
+#: src/views/website/IndexView.vue:389
 msgid "Batch Delete"
 msgstr "批量刪除"
 
@@ -3838,20 +3839,20 @@ msgstr "自動更新"
 msgid "Panel HTTPS"
 msgstr "面板 HTTPS"
 
-#: src/views/setting/SettingUser.vue:43
+#: src/views/setting/SettingUser.vue:53
 msgid "2FA"
 msgstr "兩步驗證"
 
-#: src/views/setting/SettingUser.vue:58
+#: src/views/setting/SettingUser.vue:68
 msgid "Disabled successfully"
 msgstr "禁用成功"
 
-#: src/views/setting/SettingUser.vue:93
+#: src/views/setting/SettingUser.vue:103
 #: src/views/setting/TokenModal.vue:204
 msgid "Access Tokens"
 msgstr "訪問令牌"
 
-#: src/views/setting/SettingUser.vue:121
+#: src/views/setting/SettingUser.vue:131
 msgid "Are you sure you want to delete this user?"
 msgstr "您確定要刪除該用戶嗎？"
 
@@ -4254,12 +4255,12 @@ msgid "The format is incorrect, please check"
 msgstr "格式不正確，請檢查"
 
 #: src/views/website/BulkCreate.vue:59
-#: src/views/website/IndexView.vue:295
+#: src/views/website/IndexView.vue:327
 msgid "Website %{ name } created successfully"
 msgstr "網站 %{ name } 創建成功"
 
 #: src/views/website/BulkCreate.vue:77
-#: src/views/website/IndexView.vue:368
+#: src/views/website/IndexView.vue:400
 msgid "Bulk Create Website"
 msgstr "批量創建網站"
 
@@ -4292,7 +4293,7 @@ msgid "Remark: The remark of the website, can be empty."
 msgstr "備註：網站的備註，可以為空。"
 
 #: src/views/website/EditView.vue:54
-#: src/views/website/IndexView.vue:209
+#: src/views/website/IndexView.vue:241
 msgid "Not used"
 msgstr "未使用"
 
@@ -4374,12 +4375,12 @@ msgid "Default Document"
 msgstr "預設文件"
 
 #: src/views/website/EditView.vue:277
-#: src/views/website/IndexView.vue:448
+#: src/views/website/IndexView.vue:480
 msgid "PHP Version"
 msgstr "PHP 版本"
 
 #: src/views/website/EditView.vue:282
-#: src/views/website/IndexView.vue:452
+#: src/views/website/IndexView.vue:484
 msgid "Select PHP Version"
 msgstr "選擇 PHP 版本"
 
@@ -4446,75 +4447,91 @@ msgid "Error Log"
 msgstr "錯誤日誌"
 
 #: src/views/website/IndexView.vue:24
-#: src/views/website/IndexView.vue:411
+#: src/views/website/IndexView.vue:443
 msgid "Website Name"
 msgstr "網站名稱"
 
 #: src/views/website/IndexView.vue:77
-#: src/views/website/IndexView.vue:529
-#: src/views/website/IndexView.vue:534
+msgid "Certificate expiration"
+msgstr ""
+
+#: src/views/website/IndexView.vue:91
+msgid "Not configured"
+msgstr ""
+
+#: src/views/website/IndexView.vue:94
+msgid "Expired %{ days } days ago"
+msgstr ""
+
+#: src/views/website/IndexView.vue:99
+msgid "Expires in %{ days } days"
+msgstr ""
+
+#: src/views/website/IndexView.vue:109
+#: src/views/website/IndexView.vue:561
+#: src/views/website/IndexView.vue:566
 msgid "Remark"
 msgstr "備註"
 
-#: src/views/website/IndexView.vue:133
+#: src/views/website/IndexView.vue:165
 msgid "Are you sure you want to delete website %{ name }?"
 msgstr "您確定要刪除網站 %{ name } 嗎？"
 
-#: src/views/website/IndexView.vue:144
+#: src/views/website/IndexView.vue:176
 msgid "Delete website directory"
 msgstr "刪除網站目錄"
 
-#: src/views/website/IndexView.vue:152
+#: src/views/website/IndexView.vue:184
 msgid "Delete local database with the same name"
 msgstr "刪除同名的本地數據庫"
 
-#: src/views/website/IndexView.vue:316
+#: src/views/website/IndexView.vue:348
 msgid "Please select the websites to delete"
 msgstr "請選擇要刪除的網站"
 
-#: src/views/website/IndexView.vue:351
-#: src/views/website/IndexView.vue:545
+#: src/views/website/IndexView.vue:383
+#: src/views/website/IndexView.vue:577
 msgid "Modify Default Page"
 msgstr "修改預設頁面"
 
-#: src/views/website/IndexView.vue:361
+#: src/views/website/IndexView.vue:393
 msgid "This will delete the website directory but not the database with the same name. Are you sure you want to delete the selected websites?"
 msgstr "這將刪除網站目錄，但不會刪除同名的數據庫。您確定要刪除所選網站嗎？"
 
-#: src/views/website/IndexView.vue:372
-#: src/views/website/IndexView.vue:402
+#: src/views/website/IndexView.vue:404
+#: src/views/website/IndexView.vue:434
 msgid "Create Website"
 msgstr "創建網站"
 
-#: src/views/website/IndexView.vue:417
+#: src/views/website/IndexView.vue:449
 msgid "Recommended to use English for the website name, it cannot be modified after setting"
 msgstr "建議使用英文作為網站名稱，設置後無法修改"
 
-#: src/views/website/IndexView.vue:464
+#: src/views/website/IndexView.vue:496
 msgid "Select Database"
 msgstr "選擇數據庫"
 
-#: src/views/website/IndexView.vue:492
-#: src/views/website/IndexView.vue:497
+#: src/views/website/IndexView.vue:524
+#: src/views/website/IndexView.vue:529
 msgid "Database User"
 msgstr "數據庫用戶"
 
-#: src/views/website/IndexView.vue:506
-#: src/views/website/IndexView.vue:512
+#: src/views/website/IndexView.vue:538
+#: src/views/website/IndexView.vue:544
 msgid "Database Password"
 msgstr "數據庫密碼"
 
-#: src/views/website/IndexView.vue:523
+#: src/views/website/IndexView.vue:555
 msgid "Website root directory (if left empty, defaults to website directory/website name)"
 msgstr "網站根目錄（如果留空，默認為網站目錄/網站名稱）"
 
-#: src/views/website/IndexView.vue:553
-#: src/views/website/IndexView.vue:553
+#: src/views/website/IndexView.vue:585
+#: src/views/website/IndexView.vue:585
 msgid "Default Page"
 msgstr "默認頁面"
 
-#: src/views/website/IndexView.vue:567
-#: src/views/website/IndexView.vue:567
+#: src/views/website/IndexView.vue:599
+#: src/views/website/IndexView.vue:599
 msgid "Stop Page"
 msgstr "停止頁面"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增与网站证书过期状态相关的翻译条目，包括“证书到期”、“未配置”、“已于 %{ days } 天前过期”和“将在 %{ days } 天后过期”（目前为未翻译状态）。

* **文档**
  * 更新了简体中文和繁体中文的翻译文件以同步最新的源代码引用行号。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->